### PR TITLE
Add featured deadline view 

### DIFF
--- a/TimeFlare.xcodeproj/project.pbxproj
+++ b/TimeFlare.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		A9A1781A2A9D326F000B62A7 /* DeadlineDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A178192A9D326F000B62A7 /* DeadlineDashboard.swift */; };
 		A9A1781D2A9D34C0000B62A7 /* Image+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A1781C2A9D34C0000B62A7 /* Image+Extension.swift */; };
 		A9A178202A9D3721000B62A7 /* DashboardToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A1781F2A9D3721000B62A7 /* DashboardToolbar.swift */; };
+		A9A7A0012AA30A3400C3FCAA /* EmptyDeadlinesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A7A0002AA30A3400C3FCAA /* EmptyDeadlinesView.swift */; };
 		A9B774972A9FE7310037E598 /* DeadlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B774962A9FE7310037E598 /* DeadlineView.swift */; };
 		A9B7749C2AA0558A0037E598 /* CountdownDateTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B7749B2AA0558A0037E598 /* CountdownDateTimer.swift */; };
 		A9B7749E2AA056900037E598 /* DateUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B7749D2AA056900037E598 /* DateUtil.swift */; };
@@ -89,6 +90,7 @@
 		A9A178192A9D326F000B62A7 /* DeadlineDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeadlineDashboard.swift; sourceTree = "<group>"; };
 		A9A1781C2A9D34C0000B62A7 /* Image+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Extension.swift"; sourceTree = "<group>"; };
 		A9A1781F2A9D3721000B62A7 /* DashboardToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardToolbar.swift; sourceTree = "<group>"; };
+		A9A7A0002AA30A3400C3FCAA /* EmptyDeadlinesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyDeadlinesView.swift; sourceTree = "<group>"; };
 		A9B774962A9FE7310037E598 /* DeadlineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeadlineView.swift; sourceTree = "<group>"; };
 		A9B7749B2AA0558A0037E598 /* CountdownDateTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownDateTimer.swift; sourceTree = "<group>"; };
 		A9B7749D2AA056900037E598 /* DateUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateUtil.swift; sourceTree = "<group>"; };
@@ -217,6 +219,7 @@
 				A9CCCB6B2A9EF023006B45AD /* InputDatePicker.swift */,
 				A9B7749B2AA0558A0037E598 /* CountdownDateTimer.swift */,
 				A9B774A12AA113480037E598 /* DefaultImageThumbnail.swift */,
+				A9A7A0002AA30A3400C3FCAA /* EmptyDeadlinesView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -336,6 +339,7 @@
 				A98F28932A9A9FB0002585F5 /* DeadlineRow.swift in Sources */,
 				A98F287E2A99CB67002585F5 /* MainContentView.swift in Sources */,
 				A9200BAC2A9EAE1B0017C9BA /* NonEditingImagePickerView.swift in Sources */,
+				A9A7A0012AA30A3400C3FCAA /* EmptyDeadlinesView.swift in Sources */,
 				A9B774972A9FE7310037E598 /* DeadlineView.swift in Sources */,
 				A9200BA52A9E796C0017C9BA /* ImagePickerView.swift in Sources */,
 				A98F287C2A99CB67002585F5 /* TimeFlareApp.swift in Sources */,

--- a/TimeFlare.xcodeproj/project.pbxproj
+++ b/TimeFlare.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		A9200BAE2A9EB7E30017C9BA /* InputTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9200BAD2A9EB7E30017C9BA /* InputTextField.swift */; };
 		A9242A5E2AA14D15005C1BF5 /* DeadlineSchemaMigrationPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9242A5D2AA14D15005C1BF5 /* DeadlineSchemaMigrationPlan.swift */; };
 		A9242A602AA14D52005C1BF5 /* DeadlineStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9242A5F2AA14D52005C1BF5 /* DeadlineStorage.swift */; };
+		A9242A622AA1ACB1005C1BF5 /* FeaturedDeadline.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9242A612AA1ACB1005C1BF5 /* FeaturedDeadline.swift */; };
 		A98F287C2A99CB67002585F5 /* TimeFlareApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98F287B2A99CB67002585F5 /* TimeFlareApp.swift */; };
 		A98F287E2A99CB67002585F5 /* MainContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98F287D2A99CB67002585F5 /* MainContentView.swift */; };
 		A98F28802A99CB6C002585F5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A98F287F2A99CB6C002585F5 /* Assets.xcassets */; };
@@ -73,6 +74,7 @@
 		A9200BAD2A9EB7E30017C9BA /* InputTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputTextField.swift; sourceTree = "<group>"; };
 		A9242A5D2AA14D15005C1BF5 /* DeadlineSchemaMigrationPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeadlineSchemaMigrationPlan.swift; sourceTree = "<group>"; };
 		A9242A5F2AA14D52005C1BF5 /* DeadlineStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeadlineStorage.swift; sourceTree = "<group>"; };
+		A9242A612AA1ACB1005C1BF5 /* FeaturedDeadline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedDeadline.swift; sourceTree = "<group>"; };
 		A98F287B2A99CB67002585F5 /* TimeFlareApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeFlareApp.swift; sourceTree = "<group>"; };
 		A98F287D2A99CB67002585F5 /* MainContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainContentView.swift; sourceTree = "<group>"; };
 		A98F287F2A99CB6C002585F5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 				A9A178192A9D326F000B62A7 /* DeadlineDashboard.swift */,
 				A9200BA22A9DC2BF0017C9BA /* NewDeadlineForm.swift */,
 				A9B774962A9FE7310037E598 /* DeadlineView.swift */,
+				A9242A612AA1ACB1005C1BF5 /* FeaturedDeadline.swift */,
 			);
 			path = Deadline;
 			sourceTree = "<group>";
@@ -350,6 +353,7 @@
 				A9A178202A9D3721000B62A7 /* DashboardToolbar.swift in Sources */,
 				A98F28A32A9D224D002585F5 /* SampleDeadline.swift in Sources */,
 				A9200BA32A9DC2BF0017C9BA /* NewDeadlineForm.swift in Sources */,
+				A9242A622AA1ACB1005C1BF5 /* FeaturedDeadline.swift in Sources */,
 				A9200BAE2A9EB7E30017C9BA /* InputTextField.swift in Sources */,
 				A9A178182A9D2ED4000B62A7 /* Data+Extension.swift in Sources */,
 				A9B774A52AA13D5A0037E598 /* Injected.swift in Sources */,

--- a/TimeFlare/Assets.xcassets/Colors/ForestGreen.colorset/Contents.json
+++ b/TimeFlare/Assets.xcassets/Colors/ForestGreen.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.192",
+          "green" : "0.545",
+          "red" : "0.302"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TimeFlare/Assets.xcassets/Colors/MikadoYellow.colorset/Contents.json
+++ b/TimeFlare/Assets.xcassets/Colors/MikadoYellow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.784",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TimeFlare/Assets.xcassets/Colors/OrangeWheel.colorset/Contents.json
+++ b/TimeFlare/Assets.xcassets/Colors/OrangeWheel.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.153",
+          "green" : "0.518",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TimeFlare/Assets.xcassets/Colors/Teal.colorset/Contents.json
+++ b/TimeFlare/Assets.xcassets/Colors/Teal.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "0.910"
+          "blue" : "0.667",
+          "green" : "0.710",
+          "red" : "0.012"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "0.910"
+          "blue" : "0.667",
+          "green" : "0.710",
+          "red" : "0.012"
         }
       },
       "idiom" : "universal"
@@ -41,9 +41,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.441",
-          "green" : "0.366",
-          "red" : "0.000"
+          "blue" : "0.443",
+          "green" : "0.475",
+          "red" : "0.012"
         }
       },
       "idiom" : "universal"

--- a/TimeFlare/Models/DeadlineManager.swift
+++ b/TimeFlare/Models/DeadlineManager.swift
@@ -57,6 +57,25 @@ class DeadlineManager: ObservableObject {
         })
     }
     
+    func delete(deadlines: [Deadline]) {
+        for deadline in deadlines {
+            storage.delete(deadline: deadline)
+        }
+        refreshDeadlines()
+    }
+    
+    func setAsFeatured(_ newFeaturedDeadline: Deadline, featured: Bool) {
+        if featured {
+            for deadline in allDeadlines {
+                deadline.featured = false
+            }
+            
+            newFeaturedDeadline.featured = true
+        } else {
+            newFeaturedDeadline.featured = false
+        }
+    }
+    
     func save(deadline: Deadline) {
         storage.insert(deadline: deadline)
         refreshDeadlines()

--- a/TimeFlare/Models/DeadlineStorage.swift
+++ b/TimeFlare/Models/DeadlineStorage.swift
@@ -16,6 +16,8 @@ protocol DeadlineStorageProtocol {
     
     func insert(deadline: Deadline)
     func delete(deadline: Deadline)
+    
+    func commit()
 }
 
 class DeadlineStorage: DeadlineStorageProtocol {
@@ -51,6 +53,14 @@ class DeadlineStorage: DeadlineStorageProtocol {
     
     func delete(deadline: Deadline) {
         modelContext?.delete(deadline)
+    }
+    
+    func commit() {
+        do {
+            try modelContext?.save()
+        } catch {
+            print("[DeadlineStorage] Failed to save changes")
+        }
     }
     
     func fetchAll<T: Comparable>(sortyBy: KeyPath<Deadline, T>, reverse: Bool = false) -> [Deadline] {

--- a/TimeFlare/Models/DeadlineStorage.swift
+++ b/TimeFlare/Models/DeadlineStorage.swift
@@ -10,65 +10,62 @@ import SwiftData
 
 protocol DeadlineStorageProtocol {
     
-    func setup()
+    func setup() async
     
-    func fetchAll<T: Comparable>(sortyBy: KeyPath<Deadline, T>, reverse: Bool) -> [Deadline]
+    func fetchAll<T: Comparable>(sortyBy: KeyPath<Deadline, T>, reverse: Bool) async -> [Deadline]
     
-    func insert(deadline: Deadline)
-    func delete(deadline: Deadline)
+    func insert(deadline: Deadline) async
+    func delete(deadline: Deadline) async
     
-    func commit()
+    func commit() async
 }
 
 class DeadlineStorage: DeadlineStorageProtocol {
     
     private var modelContainer: ModelContainer?
-    private var modelContext: ModelContext?
     
     func setup() {
         self.modelContainer = try? ModelContainer(
             for: Deadline.self,
             migrationPlan: DeadlineSchemaMigrationPlan.self
         )
-        
-        if let modelContainer = modelContainer {
-            modelContext = ModelContext(modelContainer)
-        }
     }
     
     @MainActor
     func setup(modelContainer: ModelContainer) {
         self.modelContainer = modelContainer
         
-        modelContext = ModelContext(modelContainer)
-        
         for deadline in SampleDeadline.sampleDeadlines {
-            modelContext?.insert(deadline)
+            modelContainer.mainContext.insert(deadline)
         }
     }
     
+    @MainActor
     func insert(deadline: Deadline) {
-        modelContext?.insert(deadline)
+        modelContainer?.mainContext.insert(deadline)
     }
     
+    @MainActor
     func delete(deadline: Deadline) {
-        modelContext?.delete(deadline)
+        modelContainer?.mainContext.delete(deadline)
     }
     
+    @MainActor
     func commit() {
         do {
-            try modelContext?.save()
+            try modelContainer?.mainContext.save()
         } catch {
             print("[DeadlineStorage] Failed to save changes")
         }
     }
     
+    @MainActor
     func fetchAll<T: Comparable>(sortyBy: KeyPath<Deadline, T>, reverse: Bool = false) -> [Deadline] {
         let sortDescriptor = SortDescriptor<Deadline>(sortyBy, order: reverse ? .reverse : .forward)
         let fetchDescriptor = FetchDescriptor<Deadline>(sortBy: [sortDescriptor])
         
         do {
-            return try modelContext?.fetch(fetchDescriptor) ?? []
+            return try modelContainer?.mainContext.fetch(fetchDescriptor) ?? []
         } catch {
             return []
         }

--- a/TimeFlare/Resources/SampleDeadline.swift
+++ b/TimeFlare/Resources/SampleDeadline.swift
@@ -19,7 +19,7 @@ class SampleDeadline {
             Deadline(
                 title: "CSE 150 Project",
                 body: "Work on a deadlock preventation algorithm",
-                endDate: Date.now + TimeInterval(3600),
+                endDate: Date.now + TimeInterval(75650000),
                 creationDate: Date.now,
                 imageData: sampleImageData
             ),
@@ -29,6 +29,21 @@ class SampleDeadline {
                 endDate: Date.now + TimeInterval(3600),
                 creationDate: Date.now,
                 imageData: sampleImageData
+            ),
+            Deadline(
+                title: "CSE 105 Project",
+                body: "",
+                endDate: Date.now - TimeInterval(3600),
+                creationDate: Date.now,
+                imageData: nil
+            ),
+            Deadline(
+                title: "CSE 175 Project",
+                body: "Did something with AI with a dumb teacher",
+                endDate: Date.now + TimeInterval(75650000),
+                creationDate: Date.now,
+                imageData: sampleImageData,
+                featured: true
             )
         ]
     }

--- a/TimeFlare/Views/Components/CountdownDateTimer.swift
+++ b/TimeFlare/Views/Components/CountdownDateTimer.swift
@@ -66,5 +66,5 @@ struct CountdownDateTimer: View {
 }
 
 #Preview {
-    CountdownDateTimer(endDate: Date.now + TimeInterval(7565))
+    CountdownDateTimer(endDate: Date.now + TimeInterval(75650000))
 }

--- a/TimeFlare/Views/Components/DashboardToolbar.swift
+++ b/TimeFlare/Views/Components/DashboardToolbar.swift
@@ -75,7 +75,7 @@ struct DashboardToolbar<Content: View>: ToolbarContent {
 
 #Preview {
     let deadlineManager = DeadlineManager(container: SampleDeadline.sampleDeadlineContainer)
-    return NavigationView(content: {
+    return NavigationStack(root: {
         Text("PlaceHolder")
             .toolbar(content: {
                 DashboardToolbar(addDeadlineContent: {

--- a/TimeFlare/Views/Components/DashboardToolbar.swift
+++ b/TimeFlare/Views/Components/DashboardToolbar.swift
@@ -10,10 +10,14 @@ import SwiftData
 
 struct DashboardToolbar<Content: View>: ToolbarContent {
     
+    @EnvironmentObject private var deadlineManager: DeadlineManager
+    
     @ViewBuilder var addDeadlineContent: () -> Content
     @Environment(\.editMode) private var editMode
     
     @Binding var editButtonVisible: Bool
+    
+    @State private var pickingSortType: SortType = .ascendingDate
     
     var body: some ToolbarContent {
         ToolbarItemGroup(placement: .topBarLeading) {
@@ -32,6 +36,18 @@ struct DashboardToolbar<Content: View>: ToolbarContent {
         ToolbarItemGroup(placement: .topBarTrailing) {
             LazyHStack(alignment: .center) {
                 
+                if editMode?.wrappedValue == .inactive {
+                    Menu("Sort") {
+                        Picker(selection: $pickingSortType) {
+                            ForEach(SortType.allCases, id: \.self) { sortType in
+                                Text(sortType.displayText).tag(sortType.rawValue)
+                            }
+                        } label: {
+                            Label("Sort", systemImage: "arrow.up.arrow.down")
+                        }
+                    }
+                }
+                
                 if editButtonVisible {
                     EditButton()
                 }
@@ -44,12 +60,21 @@ struct DashboardToolbar<Content: View>: ToolbarContent {
                     }
                 }
             }
+            .animation(.none, value: UUID())
+            .onAppear(perform: {
+                pickingSortType = deadlineManager.sortBy
+            })
+            .onChange(of: pickingSortType, initial: false) {
+                deadlineManager.setSortPreference(sortBy: pickingSortType)
+            }
+            
         }
     }
     
 }
 
 #Preview {
+    let deadlineManager = DeadlineManager(container: SampleDeadline.sampleDeadlineContainer)
     return NavigationView(content: {
         Text("PlaceHolder")
             .toolbar(content: {
@@ -57,5 +82,6 @@ struct DashboardToolbar<Content: View>: ToolbarContent {
                     Text("Add")
                 }, editButtonVisible: .constant(true))
             })
+            .environmentObject(deadlineManager)
     })
 }

--- a/TimeFlare/Views/Components/EmptyDeadlinesView.swift
+++ b/TimeFlare/Views/Components/EmptyDeadlinesView.swift
@@ -1,0 +1,36 @@
+//
+//  EmptyDeadlinesView.swift
+//  TimeFlare
+//
+//  Created by Ricardo Sanchez-Macias on 9/1/23.
+//
+
+import SwiftUI
+
+struct EmptyDeadlinesView: View {
+    var body: some View {
+        VStack(alignment: .center, content: {
+            HStack(content: {
+                Image(systemName: "questionmark.circle")
+                Text("There are no deadlines to see...")
+            })
+            .padding()
+            .font(.headline)
+            
+            Text("Click on \"Add\" to get started and see countdowns for any upcoming deadlines!")
+            .multilineTextAlignment(.center)
+            .padding(.bottom, 32)
+        })
+        .padding()
+        .frame(height: 175)
+        .background(Color.gray.opacity(0.40))
+        .clipShape(.rect(cornerRadius: 16))
+    }
+}
+
+#Preview {
+    let container = SampleDeadline.sampleDeadlineContainer
+    let manager = DeadlineManager(container: container)
+    return EmptyDeadlinesView()
+        .environmentObject(manager)
+}

--- a/TimeFlare/Views/Deadline/DeadlineDashboard.swift
+++ b/TimeFlare/Views/Deadline/DeadlineDashboard.swift
@@ -13,11 +13,28 @@ struct DeadlineDashboard: View {
     @EnvironmentObject private var deadlineManager: DeadlineManager
     
     @State private var editButtonVisible: Bool = false
+    @State private var showConfirmationForDeletingOldDeadlines: Bool = false
     
     var body: some View {
         NavigationView(content: {
             
             List {
+                // TODO: - Clean up featured deadline, not happy with current implementation
+                if let featured = deadlineManager.featuredDeadline {
+                    
+                    FeaturedDeadline(deadline: featured)
+                    .frame(height: 200)
+                    .listRowInsets(EdgeInsets())
+                    .overlay {
+                        NavigationLink {
+                            DeadlineView(deadline: featured)
+                        } label: {
+                            EmptyView()
+                        }
+                        .opacity(0)   
+                    }
+                }
+                
                 if !deadlineManager.ongoingDeadlines.isEmpty {
                     Section {
                         ForEach(deadlineManager.ongoingDeadlines) { ongoingDeadline in
@@ -35,7 +52,7 @@ struct DeadlineDashboard: View {
                     } header: {
                         HStack(alignment: .center) {
                             Label("Ongoing deadlines", systemImage: "clock")
-                                .font(.headline)
+                            .font(.system(size: 16, weight: .semibold))
                             Spacer()
                         }
                     }
@@ -59,16 +76,15 @@ struct DeadlineDashboard: View {
                     } header: {
                         HStack(alignment: .center) {
                             Label("Expired deadlines", systemImage: "clock.badge.checkmark")
-                                .font(.headline)
+                            .font(.system(size: 16, weight: .semibold))
                             Spacer()
                             Button {
-                                // TODO: - Delete all deadlines, but first show an alert for confirmation
+                                showConfirmationForDeletingOldDeadlines = true
                             } label: {
                                 Label("Delete expired deadlines", systemImage: "trash")
-                                    .labelStyle(.iconOnly)
-                                    .foregroundStyle(Color.red)
+                                .labelStyle(.iconOnly)
+                                .foregroundStyle(Color.red)
                             }
-
                         }
                     }
                 }
@@ -76,6 +92,7 @@ struct DeadlineDashboard: View {
             }
             .navigationBarTitleDisplayMode(.inline)
             .overlay {
+                // TODO: - Move no deadlines view to its own component
                 if deadlineManager.allDeadlines.isEmpty {
                     VStack(alignment: .center, content: {
                         HStack(content: {
@@ -86,8 +103,8 @@ struct DeadlineDashboard: View {
                         .font(.headline)
                         
                         Text("Click on \"Add\" to get started and see countdowns for any upcoming deadlines!")
-                            .multilineTextAlignment(.center)
-                            .padding(.bottom, 32)
+                        .multilineTextAlignment(.center)
+                        .padding(.bottom, 32)
                     })
                     .padding()
                     .frame(height: 175)
@@ -96,6 +113,26 @@ struct DeadlineDashboard: View {
                     .offset(y: -150)
                 }
             }
+            .alert(
+                "Are you sure you want to delete all expired deadlines?",
+                isPresented: $showConfirmationForDeletingOldDeadlines,
+                actions: {
+                    Button(role: .destructive) {
+                        deadlineManager.delete(deadlines: deadlineManager.expiredDeadlines)
+                        showConfirmationForDeletingOldDeadlines = false
+                    } label: {
+                        Text("Delete")
+                    }
+                    
+                    Button(role: .cancel) {
+                        showConfirmationForDeletingOldDeadlines = false
+                    } label: {
+                        Text("Cancel")
+                    }
+
+                }
+                // TODO: - Refactor alert into its own view
+            )
             .toolbar {
                 DashboardToolbar(
                     addDeadlineContent: {

--- a/TimeFlare/Views/Deadline/DeadlineDashboard.swift
+++ b/TimeFlare/Views/Deadline/DeadlineDashboard.swift
@@ -92,25 +92,9 @@ struct DeadlineDashboard: View {
             }
             .navigationBarTitleDisplayMode(.inline)
             .overlay {
-                // TODO: - Move no deadlines view to its own component
                 if deadlineManager.allDeadlines.isEmpty {
-                    VStack(alignment: .center, content: {
-                        HStack(content: {
-                            Image(systemName: "questionmark.circle")
-                            Text("There are no deadlines to see...")
-                        })
-                        .padding()
-                        .font(.headline)
-                        
-                        Text("Click on \"Add\" to get started and see countdowns for any upcoming deadlines!")
-                        .multilineTextAlignment(.center)
-                        .padding(.bottom, 32)
-                    })
-                    .padding()
-                    .frame(height: 175)
-                    .background(Color.gray.opacity(0.40))
-                    .clipShape(.rect(cornerRadius: 16))
-                    .offset(y: -150)
+                    EmptyDeadlinesView()
+                        .offset(y: -150)
                 }
             }
             .alert(

--- a/TimeFlare/Views/Deadline/DeadlineDashboard.swift
+++ b/TimeFlare/Views/Deadline/DeadlineDashboard.swift
@@ -16,7 +16,7 @@ struct DeadlineDashboard: View {
     @State private var showConfirmationForDeletingOldDeadlines: Bool = false
     
     var body: some View {
-        NavigationView(content: {
+        NavigationStack(root: {
             
             List {
                 // TODO: - Clean up featured deadline, not happy with current implementation
@@ -47,7 +47,10 @@ struct DeadlineDashboard: View {
                             }
                         }
                         .onDelete { indexSet in
-                            deadlineManager.deleteDeadlineAt(indexSet: indexSet)
+                            deadlineManager.deleteDeadlineInIndexSetFromList(
+                                indexSet: indexSet,
+                                deadlines: deadlineManager.ongoingDeadlines
+                            )
                         }
                     } header: {
                         HStack(alignment: .center) {
@@ -71,7 +74,10 @@ struct DeadlineDashboard: View {
                             }
                         }
                         .onDelete { indexSet in
-                            deadlineManager.deleteDeadlineAt(indexSet: indexSet)
+                            deadlineManager.deleteDeadlineInIndexSetFromList(
+                                indexSet: indexSet,
+                                deadlines: deadlineManager.expiredDeadlines
+                            )
                         }
                     } header: {
                         HStack(alignment: .center) {

--- a/TimeFlare/Views/Deadline/DeadlineView.swift
+++ b/TimeFlare/Views/Deadline/DeadlineView.swift
@@ -114,7 +114,6 @@ struct DeadlineView: View {
                             }
                         }
                     }
-                    
                     Spacer()
                 }
                 .padding([.leading, .trailing], 32)

--- a/TimeFlare/Views/Deadline/DeadlineView.swift
+++ b/TimeFlare/Views/Deadline/DeadlineView.swift
@@ -11,6 +11,8 @@ struct DeadlineView: View {
     
     var deadline: Deadline
     
+    @EnvironmentObject private var deadlineManager: DeadlineManager
+    
     @State private var editing: Bool = false
     
     @State private var newTitleText: String = ""
@@ -64,7 +66,10 @@ struct DeadlineView: View {
                                         .font(.system(size: 18, weight: .bold))
                                     Spacer()
                                     Button {
-                                        deadline.featured.toggle()
+                                        deadlineManager.setAsFeatured(
+                                            deadline,
+                                            featured: !deadline.featured
+                                        )
                                     } label: {
                                         Label("Set as featured deadline", systemImage: deadline.featured ? "star.fill" : "star" )
                                             .labelStyle(.iconOnly)

--- a/TimeFlare/Views/Deadline/DeadlineView.swift
+++ b/TimeFlare/Views/Deadline/DeadlineView.swift
@@ -190,7 +190,7 @@ struct DeadlineView: View {
 #Preview {
     let container = SampleDeadline.sampleDeadlineContainer
     let deadlines = SampleDeadline.sampleDeadlines
-    return NavigationView(content: {
+    return NavigationStack(root: {
         DeadlineView(deadline: deadlines[0])
             .modelContainer(container)
     })

--- a/TimeFlare/Views/Deadline/FeaturedDeadline.swift
+++ b/TimeFlare/Views/Deadline/FeaturedDeadline.swift
@@ -1,0 +1,86 @@
+//
+//  FeaturedDeadline.swift
+//  TimeFlare
+//
+//  Created by Ricardo Sanchez-Macias on 8/31/23.
+//
+
+import SwiftUI
+
+struct FeaturedDeadline: View {
+    
+    var deadline: Deadline
+    
+    var gradient: LinearGradient {
+        .linearGradient(
+            Gradient(colors: [.black.opacity(0.9), .black.opacity(0)]),
+            startPoint: .bottom,
+            endPoint: .top
+        )
+    }
+    
+    var body: some View {
+        GeometryReader(content: { geometry in
+            if deadline.image != nil {
+                deadline.image?
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .opacity(0.3)
+                    .frame(height: 200)
+                    .clipped()
+                    .overlay(content: {
+                        ZStack {
+                            gradient
+                            HStack(spacing: 24, content: {
+                                VStack(alignment: .leading, spacing: 4, content: {
+                                    Text(deadline.title)
+                                        .font(.headline)
+                                        .lineLimit(0)
+                                    Text(deadline.endDate, format: .dateTime)
+                                        .font(.subheadline)
+                                    if let body = deadline.body {
+                                        Text(body)
+                                            .font(.caption)
+                                            .lineLimit(2)
+                                            .padding(.top, 4)
+                                    }
+                                })
+                                .padding(.leading, 16)
+                                
+                                Rectangle()
+                                    .fill(Color.white)
+                                    .frame(width: 2)
+                                    .padding([.top, .bottom])
+                                CountdownDateTimer(endDate: deadline.endDate)
+                                    .font(.system(size: 14))
+                                    .frame(width: min(geometry.size.width * 0.40, 80))
+                                    .padding(.trailing, 16)
+                            })
+                            .bold()
+                            .frame(width: geometry.size.width)
+                            .foregroundStyle(Color.white)
+                            .background(Color.black.opacity(0.3))
+                        }
+                    })
+            } else {
+                Color.mikadoYellow
+                    .opacity(0.7)
+                    .frame(width: .infinity, height: 200)
+                    .clipped()
+                    .overlay(content: {
+                        ZStack {
+                            gradient
+                        }
+                    })
+            }
+        })
+    }
+}
+
+#Preview {
+    let container = SampleDeadline.sampleDeadlineContainer
+    let manager = DeadlineManager(container: container)
+    return FeaturedDeadline(deadline: SampleDeadline.sampleDeadlines[0])
+        .environmentObject(manager)
+        .frame(height: 150)
+}

--- a/TimeFlare/Views/Deadline/FeaturedDeadline.swift
+++ b/TimeFlare/Views/Deadline/FeaturedDeadline.swift
@@ -65,11 +65,45 @@ struct FeaturedDeadline: View {
             } else {
                 Color.mikadoYellow
                     .opacity(0.7)
-                    .frame(width: .infinity, height: 200)
+                    .frame(height: 200)
                     .clipped()
                     .overlay(content: {
                         ZStack {
                             gradient
+                        }
+                    })
+                    .overlay(content: {
+                        ZStack {
+                            gradient
+                            HStack(spacing: 24, content: {
+                                VStack(alignment: .leading, spacing: 4, content: {
+                                    Text(deadline.title)
+                                        .font(.headline)
+                                        .lineLimit(0)
+                                    Text(deadline.endDate, format: .dateTime)
+                                        .font(.subheadline)
+                                    if let body = deadline.body {
+                                        Text(body)
+                                            .font(.caption)
+                                            .lineLimit(2)
+                                            .padding(.top, 4)
+                                    }
+                                })
+                                .padding(.leading, 16)
+                                
+                                Rectangle()
+                                    .fill(Color.white)
+                                    .frame(width: 2)
+                                    .padding([.top, .bottom])
+                                CountdownDateTimer(endDate: deadline.endDate)
+                                    .font(.system(size: 14))
+                                    .frame(width: min(geometry.size.width * 0.40, 80))
+                                    .padding(.trailing, 16)
+                            })
+                            .bold()
+                            .frame(width: geometry.size.width)
+                            .foregroundStyle(Color.white)
+                            .background(Color.black.opacity(0.3))
                         }
                     })
             }

--- a/TimeFlare/Views/Deadline/NewDeadlineForm.swift
+++ b/TimeFlare/Views/Deadline/NewDeadlineForm.swift
@@ -89,7 +89,7 @@ extension NewDeadlineForm {
 }
 
 #Preview {
-    return NavigationView {
+    return NavigationStack {
         NewDeadlineForm()
     }
 }


### PR DESCRIPTION
**Main change:**  
Added the featured deadline view to the top of the dashboard list. The user can only keep one featured deadline at a time; the same deadline will shown in the home widget. 

**Fixes:**

- Fixed race conditions when accessing the core data due to CRUD operations being done on the background queue
- Removed deprecated usage of NavigationView. 
